### PR TITLE
feat(ui): add initial navigation skeleton with base pages

### DIFF
--- a/WispManager.UI/MainWindow.xaml
+++ b/WispManager.UI/MainWindow.xaml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Window
     x:Class="WispManager.UI.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -7,13 +6,23 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="WispManager.UI">
+    Title="Wisp Manager.UI">
 
-    <Window.SystemBackdrop>
-        <MicaBackdrop />
-    </Window.SystemBackdrop>
+    <NavigationView 
+        x:Name="NavView"
+        PaneDisplayMode="Left"
+        IsSettingsVisible="True"
+        IsBackButtonVisible="Auto"
+        IsPaneOpen="False"
+        >
+        <NavigationView.MenuItems>
+            <NavigationViewItem Content="Inicio" Icon="Home" Tag="home"/>
+            <NavigationViewItem Content="Clientes" Icon="Contact" Tag="clients"/>
+            <NavigationViewItem Content="Planes" Icon="Play" Tag="plans"/>
+            <NavigationViewItem Content="Inventario" Icon="Library" Tag="inventory"/>
+            <NavigationViewItem Content="Routers" Icon="Admin" Tag="routers"/>
+        </NavigationView.MenuItems>
 
-    <Grid>
-
-    </Grid>
+        <Frame x:Name="ContentFrame"/>
+    </NavigationView>
 </Window>

--- a/WispManager.UI/MainWindow.xaml.cs
+++ b/WispManager.UI/MainWindow.xaml.cs
@@ -1,31 +1,42 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
+using WispManager.UI.Views;
 
 namespace WispManager.UI
 {
-    /// <summary>
-    /// An empty window that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class MainWindow : Window
     {
         public MainWindow()
         {
             InitializeComponent();
+            NavView.ItemInvoked += OnItemInvoked;
+
+            NavView.SelectedItem = NavView.MenuItems[0];
+            ContentFrame.Navigate(typeof(HomePage));
+        }
+
+        private void OnItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
+        {
+            if (args.IsSettingsInvoked)
+            {
+                ContentFrame.Navigate(typeof(SettingsPage));
+                return;
+            }
+
+            var tag = (args.InvokedItemContainer as NavigationViewItem)?.Tag?.ToString();
+            switch (tag)
+            {
+                case "home":
+                    ContentFrame.Navigate(typeof(HomePage)); break;
+                case "clients":
+                    ContentFrame.Navigate(typeof(ClientsPage)); break;
+                case "plans":
+                    ContentFrame.Navigate(typeof(PlansPage)); break;
+                case "inventory":
+                    ContentFrame.Navigate(typeof(InventoryPage)); break;
+                case "routers":
+                    ContentFrame.Navigate(typeof(RouterPage)); break;
+            }
         }
     }
 }

--- a/WispManager.UI/Views/ClientsPage.xaml
+++ b/WispManager.UI/Views/ClientsPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WispManager.UI.Views.ClientsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:WispManager.UI.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+        <TextBlock Text="Página de Clientes" FontSize="24" 
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</Page>

--- a/WispManager.UI/Views/ClientsPage.xaml.cs
+++ b/WispManager.UI/Views/ClientsPage.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WispManager.UI.Views;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class ClientsPage : Page
+{
+    public ClientsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/WispManager.UI/Views/HomePage.xaml
+++ b/WispManager.UI/Views/HomePage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WispManager.UI.Views.HomePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:WispManager.UI.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+        <TextBlock Text="Página de Inicio" FontSize="24" 
+               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</Page>

--- a/WispManager.UI/Views/HomePage.xaml.cs
+++ b/WispManager.UI/Views/HomePage.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WispManager.UI.Views;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class HomePage : Page
+{
+    public HomePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/WispManager.UI/Views/InventoryPage.xaml
+++ b/WispManager.UI/Views/InventoryPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WispManager.UI.Views.InventoryPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:WispManager.UI.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+        <TextBlock Text="Página de Inventario" FontSize="24" 
+               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</Page>

--- a/WispManager.UI/Views/InventoryPage.xaml.cs
+++ b/WispManager.UI/Views/InventoryPage.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WispManager.UI.Views;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class InventoryPage : Page
+{
+    public InventoryPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/WispManager.UI/Views/PlansPage.xaml
+++ b/WispManager.UI/Views/PlansPage.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WispManager.UI.Views.PlansPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:WispManager.UI.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+
+    </Grid>
+</Page>

--- a/WispManager.UI/Views/PlansPage.xaml.cs
+++ b/WispManager.UI/Views/PlansPage.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WispManager.UI.Views;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class PlansPage : Page
+{
+    public PlansPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/WispManager.UI/Views/RouterPage.xaml
+++ b/WispManager.UI/Views/RouterPage.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WispManager.UI.Views.RouterPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:WispManager.UI.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+
+    </Grid>
+</Page>

--- a/WispManager.UI/Views/RouterPage.xaml.cs
+++ b/WispManager.UI/Views/RouterPage.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WispManager.UI.Views;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class RouterPage : Page
+{
+    public RouterPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/WispManager.UI/Views/SettingsPage.xaml
+++ b/WispManager.UI/Views/SettingsPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="WispManager.UI.Views.SettingsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:WispManager.UI.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+        <TextBlock Text="Página de Configuraciones" FontSize="24" 
+               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</Page>

--- a/WispManager.UI/Views/SettingsPage.xaml.cs
+++ b/WispManager.UI/Views/SettingsPage.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WispManager.UI.Views;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class SettingsPage : Page
+{
+    public SettingsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/WispManager.UI/WispManager.UI.csproj
+++ b/WispManager.UI/WispManager.UI.csproj
@@ -12,6 +12,14 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="Views\ClientsPage.xaml" />
+    <None Remove="Views\HomePage.xaml" />
+    <None Remove="Views\InventoryPage.xaml" />
+    <None Remove="Views\PlansPage.xaml" />
+    <None Remove="Views\RouterPage.xaml" />
+    <None Remove="Views\SettingsPage.xaml" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
@@ -43,6 +51,39 @@
   <ItemGroup>
     <ProjectReference Include="..\WispManager.Application\WispManager.Application.csproj" />
     <ProjectReference Include="..\WispManager.Infrastructure\WispManager.Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\HomePage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\ClientsPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\SettingsPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\InventoryPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="ViewModels\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\RouterPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\PlansPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
### 📌 Description
- Added base navigation skeleton using `NavigationView`
- Created menu items: Home, Clients, Plans, Inventory, Routers
- Enabled Settings via `IsSettingsVisible`
- Configured `ContentFrame` navigation system

### ✅ Checklist
- [x] Builds correctly in local
- [x] Navigation works between all pages
- [x] Placeholder pages added (to be filled later)
